### PR TITLE
Fix missing semicolons in RekAI inline script

### DIFF
--- a/source/php/Module/views/recommend.blade.php
+++ b/source/php/Module/views/recommend.blade.php
@@ -57,13 +57,13 @@ declare(strict_types=1);
                 }
             }
 
-          var advancedOptions = {}
-          var rekaiOptions = {}
+          var advancedOptions = {};
+          var rekaiOptions = {};
           try {
-            advancedOptions = JSON.parse({!! $advancedOptions !!})
-            rekaiOptions = JSON.parse(JSON.stringify({!! $rekaiOptions !!}))
+            advancedOptions = JSON.parse({!! $advancedOptions !!});
+            rekaiOptions = JSON.parse(JSON.stringify({!! $rekaiOptions !!}));
           } catch (error) {
-            console.error(error)
+            console.error(error);
           }
 
           var options = {
@@ -73,7 +73,7 @@ declare(strict_types=1);
               ...rekaiOptions,
               ...advancedOptions
             },
-          }
+          };
 
           window.__rekai.predict(options, renderHtml);
           window.__rekai.checkAndAddEventsToDOM('.modularity-mod-recommend');


### PR DESCRIPTION
Fixes missing semicolons in the RekAI inline script used by the recommend module.

Without these semicolons, the script can become invalid when minified to a single line and trigger `Uncaught SyntaxError: Unexpected token 'var'`, which prevents `window.__rekai.predict(...)` from running.